### PR TITLE
Fixed crashing issues if app is resumed and there's no object credated

### DIFF
--- a/src/android/PlusOneButtonPlugin.java
+++ b/src/android/PlusOneButtonPlugin.java
@@ -109,7 +109,9 @@ public class PlusOneButtonPlugin extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking) {
         super.onResume(multitasking);
-        mPlusOneButton.initialize(URL, null);
+        if (mPlusOneButton!=null) {
+          mPlusOneButton.initialize(URL, null);
+        }
     }
 
 }


### PR DESCRIPTION
Fix for runtime exception in the plugin when resuming app from background.
